### PR TITLE
Fix the name of the new game loading scene on the Main Menu manager

### DIFF
--- a/Assets/Scripts/Components/MainMenuGM.cs
+++ b/Assets/Scripts/Components/MainMenuGM.cs
@@ -16,7 +16,7 @@ public class MainMenuGM : MonoBehaviour {
 	}
 
 	public void newGame(){
-		SceneManager.LoadScene("game-session");
+		SceneManager.LoadScene("game-connection");
 	}
 
 	public void options(){


### PR DESCRIPTION
When executing the game from the boot, and then tapping on the `new game` button there is an unknown scene `game-session` message. 

I've changed it to `game-connection`, and seems to be working. Just wanted to make sure that this was a typo or there is an missing scene on the repo 😛  