### PR TITLE
Fix player list deserialization from UPDATE_PLAYERS command response action

### DIFF
--- a/Assets/Scripts/Classes/CommandResponse.cs
+++ b/Assets/Scripts/Classes/CommandResponse.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public class CommandResponse
 {
 	public CommandAction action;
-    public string data;
+    public string payload;
 
     public override string ToString()
     {

--- a/Assets/Scripts/Classes/Player.cs
+++ b/Assets/Scripts/Classes/Player.cs
@@ -1,9 +1,13 @@
-﻿using System.Collections;
+﻿
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[Serializable]
 public class Player
-{
+{   
+    public string id;
     public string nick;
 
     public static string ListToString(List<Player> p)
@@ -15,4 +19,10 @@ public class Player
         }
         return toRet;
     }
+}
+
+[Serializable]
+public class PlayerList
+{
+    public Player[] players;
 }

--- a/Assets/Scripts/Classes/Player.cs
+++ b/Assets/Scripts/Classes/Player.cs
@@ -25,4 +25,8 @@ public class Player
 public class PlayerList
 {
     public Player[] players;
+
+    public static List<Player> AsList(PlayerList playerList) {
+        return new List<Player>(playerList.players);
+    }
 }

--- a/Assets/Scripts/Components/GameLobbyGM.cs
+++ b/Assets/Scripts/Components/GameLobbyGM.cs
@@ -29,10 +29,30 @@ public class GameLobbyGM : MonoBehaviour
     private void OnRecieveResponse(object sender, WebSocketSharp.MessageEventArgs e)
     {
         // TODO: Handle players joining the lobby.
-        CommandResponse c = JsonUtility.FromJson<CommandResponse>(e.Data);
+        
+        CommandResponse c;
+
+        try { 
+            c = JsonUtility.FromJson<CommandResponse>(e.Data);
+        } catch(NullReferenceException) {
+            Debug.LogWarning("Wrong Command Response serialization");
+            c = null;
+        }
+
+        if (c == null) {
+            return;
+        }
+
         if (c.action == CommandAction.UPDATE_PLAYERS)
         {
-            UpdatePlayerList(JsonUtility.FromJson<List<Player>>(c.data));
+            try {
+                PlayerList playerList = JsonUtility.FromJson<PlayerList>(c.payload);
+                UpdatePlayerList(PlayerList.AsList(playerList));
+            } catch(NullReferenceException) { 
+                Debug.LogWarning("Wrong Player payload serialization");
+            } catch(UnityException err) {
+                Debug.LogError(err);
+            }
         }
         Debug.Log("Recieved a CommandResponse:");
         Debug.Log(c.ToString());


### PR DESCRIPTION
This pull request fixes #2 issue that we were having when parsing Json list received on command response payloads.